### PR TITLE
Use datetime stamp as output filenames

### DIFF
--- a/getHomeBrewJson.rb
+++ b/getHomeBrewJson.rb
@@ -16,9 +16,9 @@ packages = JSON.parse(response)
 # Create directory if does not exist
 FileUtils.mkdir_p directory unless Dir.exists?(directory)
 
-puts "- Generating datestamp"
-time = Time.new
-date = time.strftime("%Y-%m-%d")
+puts "- Generating datetime stamp"
+#Include time to the filename for uniqueness when fetching multiple times a day
+date_time = Time.new.strftime("%Y-%m-%dT%H-%M-%S")
 
 packages.each do |package|
   parsed_homebrew_package = {
@@ -32,4 +32,4 @@ end
 
 # Writing parsed data to file
 puts "- Writing data to file"
-File.write("#{directory}/#{date}.txt", parsed_homebrew_packages.join("\n"))
+File.write("#{directory}/#{date_time}.txt", parsed_homebrew_packages.join("\n"))

--- a/getRepologyJson.rb
+++ b/getRepologyJson.rb
@@ -12,11 +12,11 @@ response = Net::HTTP.get(uri)
 puts "- Parsing response"
 data = JSON.parse(response)
 
-puts "- Generating datestamp"
-time = Time.new
-date = time.strftime("%Y-%m-%d")
+puts "- Generating datetime stamp"
+#Include time to the filename for uniqueness when fetching multiple times a day
+date_time = Time.new.strftime("%Y-%m-%dT%H-%M-%S")
 
 # Create directory if does not exist
 FileUtils.mkdir_p directory unless Dir.exists?(directory)
 # Writing parsed data to file
-File.write("#{directory}/#{date}.txt", data)
+File.write("#{directory}/#{date_time}.txt", data)


### PR DESCRIPTION
USe date time stamp as file names for JSON text file from homebrew and repology API fetch so that they are uniques when we fetch many times a day.