### PR TITLE
change scheduled cron job to run every 4 hours

### DIFF
--- a/.github/workflows/schedule_CI.yml
+++ b/.github/workflows/schedule_CI.yml
@@ -1,7 +1,7 @@
 name: Schedule CI
 on:
   schedule: # Setup cron for timing
-    - cron: '*/10 * * * *'
+    - cron: '0 */4 * * *' # at 0 minutes past every 4th hr
 jobs:
   build:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
 Changes scheduled cron job to run every 4 hours instead of every 10 minutes.  

The job takes 30+ mins to complete.. we need to space these out.